### PR TITLE
Add Ordered List of Tagged Parameters in StationInfo struct

### DIFF
--- a/src/frame/components/station_info.rs
+++ b/src/frame/components/station_info.rs
@@ -13,6 +13,9 @@
 /// Since we cannot handle all all those elements, the bytes of all unhandled elements will
 /// be saved in the `data` field under the respectiv element id.
 pub struct StationInfo {
+    // The ordered list of tagged parameters transmitted by the station.
+    // Empty if no parameters were transmitted.
+    pub tagged_parameters: Vec<u8>,
     /// The transmission rates that are supported by the station.
     /// Empty if no rates were transmitted.
     pub supported_rates: Vec<f32>,

--- a/src/parsers/components/station_info.rs
+++ b/src/parsers/components/station_info.rs
@@ -28,6 +28,13 @@ pub fn parse_station_info(mut input: &[u8]) -> IResult<&[u8], StationInfo> {
         (input, data) = take(length)(input)?;
         //println!("Extracted data: {:?}", data);
 
+        // Create list of tagged parameters.
+        match element_id {
+            // Don't match extended tags.
+            id if id != 255 => station_info.tagged_parameters.push(element_id),
+            _ => {},
+        };
+
         match element_id {
             0 => {
                 let mut ssid = String::from_utf8_lossy(data).to_string();


### PR DESCRIPTION
Adds an ordered list of tagged wireless management parameters to the StationInfo struct.