### PR TITLE
Add HT Capability Information Element Extraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ strum_macros = "0.24"
 enum_dispatch = "0.3"
 
 libwifi_macros = { version="0.0.2", path="libwifi_macros" }
+hex = "0.4.3"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/frame/components/station_info.rs
+++ b/src/frame/components/station_info.rs
@@ -18,6 +18,12 @@ pub struct StationInfo {
     pub supported_rates: Vec<f32>,
     /// If the sender included a SSID, it will be in here.
     pub ssid: Option<String>,
+    // The HT Capabilities Information bitmask, if transmitted.
+    pub ht_capabilities_info: Option<String>,
+    // The HT Capabilities A-MPDU parameters bitmask, if transmitted.
+    pub ht_a_mpdu_parameters: Option<String>,
+    // The HT Capabilities RX Supported Modulation and Coding Scheme bitmask, if transmitted.
+    pub ht_rx_mcs: Option<String>,
     /// This map contains all fields that aren't explicitly parsed by us.
     /// The format is Vec<(FieldId, PayloadBytes)>.
     ///


### PR DESCRIPTION
Adds the ability to pull the following fields from StationInfo structs:
- HT Capabilities Bitmask
- RX-MCS Bitmask
- A-MPDU Parameters Bitmask