### PR TITLE
Some improvements to help with debugging and stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [0.4.4] - unreleased
 
+### Added
+
+- RA, TA, DA, SA fields can now be accessed directly in Data frames (#39)
+- Frame type and subtype included in error messages for unsupported frames (#38)
+- Improved bounds checking when parsing station info data (#38)
+- Protocol versions other than 0 and extension frames are recognised and included in error messages (but they are not parsed yet) (#38)
+
+### Changes
+
+- FrameControl header field `wep` deprecated and renamed to `protected` to match the standard (#38)
+
 ### Chore
 
 - Switch to Rust 2024 edition. This bumps the MSRV to `1.85`.

--- a/libwifi/src/frame/components/frame_control.rs
+++ b/libwifi/src/frame/components/frame_control.rs
@@ -33,7 +33,7 @@ fn flag_is_set(data: u8, bit: u8) -> bool {
 /// - **bit_4** `power_mgmt`: Indicates what power mode (`save` or `active`) the station will be in, once the frame has been sent.
 /// - **bit_5** `more_data`: Set by the AP to indicate that more frames are destined to a particular station that may be in power save mode.
 ///                     These frames will be buffered at the AP, so it can be sent once the station decides to become `active`.
-/// - **bit_6** `wep`: Set if WEP is being used to encrypt the body of the frame.
+/// - **bit_6** `protected`: Set if the frame body is encrypted (protected)
 /// - **bit_7** `order`: Set if the frame is being sent according to the _Strictly Ordered Class_.
 ///
 #[derive(Clone, Debug)]
@@ -69,7 +69,12 @@ impl FrameControl {
         flag_is_set(self.flags, 5)
     }
 
+    #[deprecated(note = "please use `protected` instead")]
     pub fn wep(&self) -> bool {
+        flag_is_set(self.flags, 6)
+    }
+
+    pub fn protected(&self) -> bool {
         flag_is_set(self.flags, 6)
     }
 
@@ -102,7 +107,7 @@ mod tests {
             3 => frame_control.retry(),
             4 => frame_control.pwr_mgmt(),
             5 => frame_control.more_data(),
-            6 => frame_control.wep(),
+            6 => frame_control.protected(),
             7 => frame_control.order(),
             _ => panic!("Unhandled bit {bit}"),
         }

--- a/libwifi/src/frame/components/frame_control.rs
+++ b/libwifi/src/frame/components/frame_control.rs
@@ -17,12 +17,15 @@ fn flag_is_set(data: u8, bit: u8) -> bool {
 ///
 /// First byte:
 ///
-/// - **bit_0-1**: Protocol version.
-///     Until now, this has always been 0 and is expected to be 0.
+/// - **bit_0-1**: [FrameProtocolVersion]
 /// - **bit_2-3**: [FrameType]
 /// - **bit_4-7**: [FrameSubType]
 ///
-/// Second byte (Flags):
+/// The values of the remaining bytes depend on protocol version, frame type and sub type.
+///
+/// In the general case:
+///
+/// PV0 Second byte (Flags):
 /// - **bit_0** `to_ds`: Set if the frame is to be sent by the AP to the distribution system.
 /// - **bit_1** `from_ds`: Set if the frame is from the distribution system.
 /// - **bit_2** `more_frag`: Set if this frame is a fragment of a bigger frame and there are more fragments to follow.
@@ -32,9 +35,10 @@ fn flag_is_set(data: u8, bit: u8) -> bool {
 ///                     These frames will be buffered at the AP, so it can be sent once the station decides to become `active`.
 /// - **bit_6** `wep`: Set if WEP is being used to encrypt the body of the frame.
 /// - **bit_7** `order`: Set if the frame is being sent according to the _Strictly Ordered Class_.
+///
 #[derive(Clone, Debug)]
 pub struct FrameControl {
-    pub protocol_version: u8,
+    pub protocol_version: FrameProtocolVersion,
     pub frame_type: FrameType,
     pub frame_subtype: FrameSubType,
     pub flags: u8,
@@ -74,7 +78,7 @@ impl FrameControl {
     }
 
     pub fn encode(&self) -> [u8; 2] {
-        let protocol_version_bits = self.protocol_version & 0b11; // 2 bits
+        let protocol_version_bits = self.protocol_version.to_bytes() & 0b11; // 2 bits
         let frame_type_bits = (self.frame_type.to_bytes() & 0b11) << 2; // 2 bits
         let frame_subtype_bits = (self.frame_subtype.to_bytes() & 0b1111) << 4; // 4 bits
 

--- a/libwifi/src/frame/components/frame_control.rs
+++ b/libwifi/src/frame/components/frame_control.rs
@@ -75,7 +75,7 @@ impl FrameControl {
 
     pub fn encode(&self) -> [u8; 2] {
         let protocol_version_bits = self.protocol_version & 0b11; // 2 bits
-        let frame_type_bits = (self.frame_type as u8 & 0b11) << 2; // 2 bits
+        let frame_type_bits = (self.frame_type.to_bytes() & 0b11) << 2; // 2 bits
         let frame_subtype_bits = (self.frame_subtype.to_bytes() & 0b1111) << 4; // 4 bits
 
         let first_byte = frame_subtype_bits | frame_type_bits | protocol_version_bits;

--- a/libwifi/src/frame_types.rs
+++ b/libwifi/src/frame_types.rs
@@ -6,6 +6,7 @@ pub enum FrameType {
     Management,
     Control,
     Data,
+    Extension,
     Unknown(u8),
 }
 
@@ -15,6 +16,7 @@ impl FrameType {
             FrameType::Management => 0,
             FrameType::Control => 1,
             FrameType::Data => 2,
+            FrameType::Extension => 3,
             FrameType::Unknown(x) => *x,
         }
     }
@@ -90,6 +92,10 @@ pub enum FrameSubType {
     QosCfPoll,
     QosCfAckCfPoll,
 
+    // Extension subtypes
+    DMGBeacon,
+    S1GBeacon,
+
     // Special subtypes
     Unhandled(u8),
     Reserved(u8),
@@ -154,6 +160,8 @@ impl FrameSubType {
             FrameSubType::QosNull => 12,
             FrameSubType::QosCfPoll => 14,
             FrameSubType::QosCfAckCfPoll => 15,
+            FrameSubType::DMGBeacon => 0,
+            FrameSubType::S1GBeacon => 1,
             FrameSubType::Unhandled(x) => *x,
             FrameSubType::Reserved(x) => *x,
         }

--- a/libwifi/src/frame_types.rs
+++ b/libwifi/src/frame_types.rs
@@ -6,7 +6,18 @@ pub enum FrameType {
     Management,
     Control,
     Data,
-    Unknown,
+    Unknown(u8),
+}
+
+impl FrameType {
+    pub fn to_bytes(&self) -> u8 {
+        match self {
+            FrameType::Management => 0,
+            FrameType::Control => 1,
+            FrameType::Data => 2,
+            FrameType::Unknown(x) => *x,
+        }
+    }
 }
 
 pub enum ManagementSubTypes {
@@ -80,8 +91,8 @@ pub enum FrameSubType {
     QosCfAckCfPoll,
 
     // Special subtypes
-    Unhandled,
-    Reserved,
+    Unhandled(u8),
+    Reserved(u8),
 }
 
 impl FrameSubType {
@@ -143,7 +154,8 @@ impl FrameSubType {
             FrameSubType::QosNull => 12,
             FrameSubType::QosCfPoll => 14,
             FrameSubType::QosCfAckCfPoll => 15,
-            _ => 255,
+            FrameSubType::Unhandled(x) => *x,
+            FrameSubType::Reserved(x) => *x,
         }
     }
 }

--- a/libwifi/src/frame_types.rs
+++ b/libwifi/src/frame_types.rs
@@ -1,5 +1,20 @@
 use strum_macros::Display;
 
+/// Enum with protocol version
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Display)]
+pub enum FrameProtocolVersion {
+    PV0,
+    Unknown(u8),
+}
+impl FrameProtocolVersion {
+    pub fn to_bytes(&self) -> u8 {
+        match self {
+            FrameProtocolVersion::PV0 => 0,
+            FrameProtocolVersion::Unknown(x) => *x,
+        }
+    }
+}
+
 /// Enum with all frame types.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Display)]
 pub enum FrameType {

--- a/libwifi/src/parsers/components/frame_control.rs
+++ b/libwifi/src/parsers/components/frame_control.rs
@@ -18,6 +18,8 @@ pub fn parse_frame_control(input: &[u8]) -> IResult<&[u8], FrameControl> {
             take(8usize),
         ))(input)?;
 
+    let protocol_version = parse_protocol_version(protocol_version);
+
     let frame_type = parse_frame_type(frame_type);
 
     // The next 4 bits are then used to determine the frame sub-type.
@@ -39,6 +41,13 @@ pub fn parse_frame_control(input: &[u8]) -> IResult<&[u8], FrameControl> {
             flags,
         },
     ))
+}
+
+fn parse_protocol_version(byte: u8) -> FrameProtocolVersion {
+    match byte {
+        0 => FrameProtocolVersion::PV0,
+        n => FrameProtocolVersion::Unknown(n),
+    }
 }
 
 /// Get the FrameType a two-bit integer (bits 3-4 of the payload).

--- a/libwifi/src/parsers/components/frame_control.rs
+++ b/libwifi/src/parsers/components/frame_control.rs
@@ -26,6 +26,7 @@ pub fn parse_frame_control(input: &[u8]) -> IResult<&[u8], FrameControl> {
         FrameType::Management => management_frame_subtype(frame_subtype),
         FrameType::Control => control_frame_subtype(frame_subtype),
         FrameType::Data => data_frame_subtype(frame_subtype),
+        FrameType::Extension => extension_frame_subtype(frame_subtype),
         FrameType::Unknown(_) => FrameSubType::Unhandled(frame_subtype),
     };
 
@@ -46,6 +47,7 @@ fn parse_frame_type(byte: u8) -> FrameType {
         0 => FrameType::Management,
         1 => FrameType::Control,
         2 => FrameType::Data,
+        3 => FrameType::Extension,
         byte => FrameType::Unknown(byte),
     }
 }
@@ -95,6 +97,16 @@ fn control_frame_subtype(byte: u8) -> FrameSubType {
         14 => FrameSubType::CfEnd,
         15 => FrameSubType::CfEndCfAck,
         x => FrameSubType::Unhandled(x),
+    }
+}
+
+/// Get the FrameSubType from a 4-bit integer (bit 4-7) under
+/// the assumption that this is an extension frame.
+fn extension_frame_subtype(byte: u8) -> FrameSubType {
+    match byte {
+        0 => FrameSubType::DMGBeacon,
+        1 => FrameSubType::S1GBeacon,
+        _ => FrameSubType::Reserved(byte),
     }
 }
 

--- a/libwifi/src/parsers/components/frame_control.rs
+++ b/libwifi/src/parsers/components/frame_control.rs
@@ -26,7 +26,7 @@ pub fn parse_frame_control(input: &[u8]) -> IResult<&[u8], FrameControl> {
         FrameType::Management => management_frame_subtype(frame_subtype),
         FrameType::Control => control_frame_subtype(frame_subtype),
         FrameType::Data => data_frame_subtype(frame_subtype),
-        FrameType::Unknown => FrameSubType::Unhandled,
+        FrameType::Unknown(_) => FrameSubType::Unhandled(frame_subtype),
     };
 
     Ok((
@@ -46,7 +46,7 @@ fn parse_frame_type(byte: u8) -> FrameType {
         0 => FrameType::Management,
         1 => FrameType::Control,
         2 => FrameType::Data,
-        _ => FrameType::Unknown,
+        byte => FrameType::Unknown(byte),
     }
 }
 
@@ -61,7 +61,7 @@ fn management_frame_subtype(byte: u8) -> FrameSubType {
         4 => FrameSubType::ProbeRequest,
         5 => FrameSubType::ProbeResponse,
         6 => FrameSubType::TimingAdvertisement,
-        7 => FrameSubType::Reserved,
+        7 => FrameSubType::Reserved(byte),
         8 => FrameSubType::Beacon,
         9 => FrameSubType::Atim,
         10 => FrameSubType::Disassociation,
@@ -69,8 +69,8 @@ fn management_frame_subtype(byte: u8) -> FrameSubType {
         12 => FrameSubType::Deauthentication,
         13 => FrameSubType::Action,
         14 => FrameSubType::ActionNoAck,
-        15 => FrameSubType::Reserved,
-        _ => FrameSubType::Unhandled,
+        15 => FrameSubType::Reserved(byte),
+        x => FrameSubType::Unhandled(x),
     }
 }
 
@@ -78,8 +78,8 @@ fn management_frame_subtype(byte: u8) -> FrameSubType {
 /// the assumption that this is a control frame.
 fn control_frame_subtype(byte: u8) -> FrameSubType {
     match byte {
-        0 => FrameSubType::Reserved,
-        1 => FrameSubType::Reserved,
+        0 => FrameSubType::Reserved(byte),
+        1 => FrameSubType::Reserved(byte),
         2 => FrameSubType::Trigger,
         3 => FrameSubType::Tack,
         4 => FrameSubType::BeamformingReportPoll,
@@ -94,7 +94,7 @@ fn control_frame_subtype(byte: u8) -> FrameSubType {
         13 => FrameSubType::Ack,
         14 => FrameSubType::CfEnd,
         15 => FrameSubType::CfEndCfAck,
-        _ => FrameSubType::Unhandled,
+        x => FrameSubType::Unhandled(x),
     }
 }
 
@@ -115,9 +115,9 @@ fn data_frame_subtype(byte: u8) -> FrameSubType {
         10 => FrameSubType::QosDataCfPoll,
         11 => FrameSubType::QosDataCfAckCfPoll,
         12 => FrameSubType::QosNull,
-        13 => FrameSubType::Reserved,
+        13 => FrameSubType::Reserved(byte),
         14 => FrameSubType::QosCfPoll,
         15 => FrameSubType::QosCfAckCfPoll,
-        _ => FrameSubType::Unhandled,
+        x => FrameSubType::Unhandled(x),
     }
 }

--- a/libwifi/src/parsers/components/station_info.rs
+++ b/libwifi/src/parsers/components/station_info.rs
@@ -398,6 +398,9 @@ pub fn parse_rsn_information(data: &[u8]) -> Result<RsnInformation, &'static str
 
     let mut pairwise_cipher_suites = Vec::new();
     for _ in 0..pairwise_cipher_suite_count {
+        if data.len() < offset + 4 {
+            return Err("Pairwise cipher suite data field too short");
+        }
         let suite = parse_pairwise_cipher_suite(&data[offset..offset + 4]);
         pairwise_cipher_suites.push(suite);
         offset += 4;
@@ -408,6 +411,9 @@ pub fn parse_rsn_information(data: &[u8]) -> Result<RsnInformation, &'static str
 
     let mut akm_suites = Vec::new();
     for _ in 0..akm_suite_count {
+        if data.len() < offset + 4 {
+            return Err("AKM suite data field too short");
+        }
         let suite = parse_akm_suite(&data[offset..offset + 4]);
         akm_suites.push(suite);
         offset += 4;


### PR DESCRIPTION
This PR adds a few features to make it easier to identify what's missing when parsing data that's not yet recognised by the library. It also adds two bounds check to fix a potential crash when monitoring with fcs disabled. The "wep" bit is renamed to "protected" to match the description in the standard. Other protocol versions than PV0 are recognised and included in errors, but not parsed (802.11-2020 adds PV1 for 802.11ah).

See individual commits for more details.