### PR TITLE
Add TA, RA, DA and SA fields to data headers

### DIFF
--- a/libwifi/src/frame/components/header.rs
+++ b/libwifi/src/frame/components/header.rs
@@ -189,6 +189,62 @@ impl DataHeader {
 
         bytes
     }
+
+    /// Receiver Address is the address of the device that received this frame. It may not be the final
+    /// destination for the frame (see [da]).
+    pub fn ra(&self) -> MacAddress {
+        self.address_1 // RA is always Address 1
+    }
+
+    /// Transmitter Address is the address of the device that transmitted this frame. It may not be
+    /// the source that created the frame (see [sa]).
+    pub fn ta(&self) -> MacAddress {
+        self.address_2 // TA is always Address 2
+    }
+
+    /// Destination Address is the intended final destination of the frame. It may not be the
+    /// address that received the frame (see [ra]).
+    ///
+    /// When transmitting via an Access Point, the Destination Address will contain the address of
+    /// the intended recipient, while Receiver Address will contain the address of the AP.
+    pub fn da(&self) -> MacAddress {
+        if self.frame_control.to_ds() && self.frame_control.from_ds() {
+            // Either DA or BSSID in this case...
+            self.address_3
+        } else if self.frame_control.to_ds() {
+            self.address_3
+        } else if self.frame_control.from_ds() {
+            // Usually DA, but note from standard:
+            // [when to_ds=0 and from_ds=1, then address 1] is equal to DA, except when an
+            // individually addressed A-MSDU frame is used in DMS and S1G relay, in which case the
+            // destination address of the frame is included in the DA field of the A-MSDU subframe
+            // (see 11.21.16 and 10.54
+            self.address_1
+        } else {
+            self.address_1 // RA = DA
+        }
+    }
+
+    /// Sender Address contains the address of the node that created this frame. It may not be the
+    /// same address as the Transmitter Address (see [ta]).
+    pub fn sa(&self) -> Option<MacAddress> {
+        if self.frame_control.to_ds() && self.frame_control.from_ds() {
+            // Address 4 is either SA or BSSID in this case
+            self.address_4
+        } else if self.frame_control.to_ds() {
+            // Note from standard:
+            // Address 2 of a frame with To DS equal to 1 and From DS equal to 0 is equal to the
+            // SA, except when an individually addressed A-MSDU frame is used in S1G relay, in
+            // which case, the source address of the frame is included in the SA field of the
+            // A-MSDU subframe (see 10.54)
+            Some(self.address_2)
+        } else if self.frame_control.from_ds() {
+            // Address 3 is either SA or BSSID in this case
+            Some(self.address_3)
+        } else {
+            Some(self.address_2) // TA = SA
+        }
+    }
 }
 
 impl Addresses for DataHeader {


### PR DESCRIPTION
As destination and source can have different meaning in different contexts, this adds the fields use by the Wi-Fi standard so they can be accessed directly. It does not handle some special cases from S1G and DMG as it's not supported by the library yet, but I added a comment in the code where it would have to be considered.

See commit message for further details.