### PR TITLE
Extend block_ack, block_ack_request tests and fix bar_control bit order

### DIFF
--- a/libwifi/Cargo.toml
+++ b/libwifi/Cargo.toml
@@ -19,6 +19,7 @@ harness = false
 name = "parse_data"
 
 [dependencies]
+bitvec = "1.0.1"
 byteorder = "1.5.0"
 crc = "3.2.1"
 enum_dispatch = "0.3"
@@ -28,6 +29,7 @@ nom = "8"
 rand = "0.9"
 strum_macros = "0.27"
 thiserror = "2.0"
+
 
 [dev-dependencies]
 criterion = "0.5"

--- a/libwifi/src/parsers/mod.rs
+++ b/libwifi/src/parsers/mod.rs
@@ -1,31 +1,5 @@
-use nom::{IResult, Needed};
-
 mod components;
 mod frame_types;
 
 pub use components::*;
 pub use frame_types::*;
-
-#[inline]
-/// Mini helper to check, whether a bit is set or not.
-fn flag_is_set(data: u8, bit: usize) -> bool {
-    if bit == 0 {
-        let mask = 1;
-        (data & mask) > 0
-    } else {
-        let mask = 1 << bit;
-        (data & mask) > 0
-    }
-}
-
-fn flag((input, bit_offset): (&[u8], usize)) -> IResult<(&[u8], usize), bool> {
-    if input.is_empty() {
-        return Err(nom::Err::Incomplete(Needed::new(1)));
-    }
-    let flag = flag_is_set(input[0], bit_offset);
-    if bit_offset == 7 {
-        return Ok(((&input[1..], 0), flag));
-    }
-
-    Ok(((input, bit_offset + 1), flag))
-}


### PR DESCRIPTION
This PR is an attempt to fix #40 by using `bitvec` to parse the bits instead. It also includes tests for the issue in block_ack and block_ack_request. Since it adds a new dependency I thought I'd submit an early PR to see what you think about this solution.

`bit_take` is also used in other parts of control.rs so these fields should probably also be tested and updated. I can take a look at it if you think this looks reasonable so far.
