### PR TITLE
Support cargo-fuzz

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-exclude = ["examples/capture_example"]
+exclude = ["examples/capture_example", "fuzz"]
 members = ["libwifi", "libwifi_macros"]
 resolver = "3"
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "libwifi-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.libwifi]
+path = "../libwifi"
+
+[[bin]]
+name = "parse_frame"
+path = "fuzz_targets/parse_frame.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse_frame.rs
+++ b/fuzz/fuzz_targets/parse_frame.rs
@@ -1,0 +1,10 @@
+#![no_main]
+
+extern crate libwifi;
+
+use libfuzzer_sys::fuzz_target;
+use libwifi::parse_frame;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = parse_frame(&data, false);
+});

--- a/libwifi/README.md
+++ b/libwifi/README.md
@@ -133,3 +133,7 @@ If we take this as a rough guideline, you can roughly expect 3-35 million frames
 
 There's a lot more to the IEE 802.11 spec and a lot of stuff needs to be done. \
 If you find that something you need is missing, consider creating a ticket and contributing :).
+
+### Fuzzing
+
+`cargo-fuzz` can be used to check for potential crashes while processing unvalidated input data. After [installing cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz) (note: may require rust nightly), the frame parsing can be tested with `cargo fuzz run parse_frame`.


### PR DESCRIPTION
This adds a `fuzz` subdirectory with a target for `cargo-fuzz`. It is currently testing `parse_frame` on generated input data.
